### PR TITLE
[MERGE] 리스트(추가, 타이틀수정), 보드 삭제, recoli-persist 적용

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "react-indexed-db": "^1.0.12",
         "react-router-dom": "^6.6.1",
         "recoil": "^0.7.6",
+        "recoil-persist": "^4.2.0",
         "shortid": "^2.2.16",
         "styled-components": "^5.3.6",
         "sweetalert2": "^11.6.16",
@@ -25470,6 +25471,14 @@
         }
       }
     },
+    "node_modules/recoil-persist": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/recoil-persist/-/recoil-persist-4.2.0.tgz",
+      "integrity": "sha512-MHVfML9GxJP3RpkKR4F5rp7DtvzIvjWhowtMao/b7h2k4afMio/4sMAdUtltIrDaeVegH0Iga8Sx5XQ3oD7CzA==",
+      "peerDependencies": {
+        "recoil": "^0.7.2"
+      }
+    },
     "node_modules/redent": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/redent/-/redent-1.0.0.tgz",
@@ -49871,6 +49880,11 @@
       "requires": {
         "hamt_plus": "1.0.2"
       }
+    },
+    "recoil-persist": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/recoil-persist/-/recoil-persist-4.2.0.tgz",
+      "integrity": "sha512-MHVfML9GxJP3RpkKR4F5rp7DtvzIvjWhowtMao/b7h2k4afMio/4sMAdUtltIrDaeVegH0Iga8Sx5XQ3oD7CzA=="
     },
     "redent": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "react-indexed-db": "^1.0.12",
     "react-router-dom": "^6.6.1",
     "recoil": "^0.7.6",
+    "recoil-persist": "^4.2.0",
     "shortid": "^2.2.16",
     "styled-components": "^5.3.6",
     "sweetalert2": "^11.6.16",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,9 +4,10 @@ import Login from '@/pages/Auth/Login/index';
 import SignUp from '@/pages/Auth/SignUp/index';
 import Workspace from '@/pages/Workspace/index';
 import BoardPage from '@/pages/Board/index';
+import Remove from '@/pages/Remove';
 
 import { BrowserRouter, Routes, Route } from 'react-router-dom';
-import { RecoilRoot, atom, selector, useRecoilState, useRecoilValue } from 'recoil';
+import { RecoilRoot } from 'recoil';
 import { ThemeProvider } from 'styled-components';
 import colors from '@/styles/colors';
 import GlobalStyle from '@/styles/GlobalStyle';
@@ -29,6 +30,7 @@ function App() {
             <Route path="/signup" element={<SignUp />}></Route>
             <Route path="/workspace" element={<Workspace />}></Route>
             <Route path="/board/:boardId" element={<BoardPage />}></Route>
+            <Route path="/remove/:boardId" element={<Remove />}></Route>
           </Routes>
         </BrowserRouter>
       </ThemeProvider>

--- a/src/components/Board/AddList.tsx
+++ b/src/components/Board/AddList.tsx
@@ -1,0 +1,63 @@
+import { useEffect, useState } from 'react';
+import * as S from '@/components/Board/AddListStyle';
+import { useParams } from 'react-router-dom';
+import { useRecoilState } from 'recoil';
+import { boardsAtom } from '@/recoil/boardsAtom';
+import shortid from 'shortid';
+
+function AddList() {
+  const { boardId } = useParams();
+  const [boards, setBoards] = useRecoilState(boardsAtom);
+  const [addStatus, setAddStatus] = useState(false);
+  const [listTitle, setListTitle] = useState('');
+
+  const handleStatusTrue = (e: any) => {
+    setAddStatus(true);
+  };
+
+  const handleStatusFalse = (e: any) => {
+    if (e.key === 'Enter') {
+      setAddStatus(false);
+      saveList();
+    } else if (e.key === 'Escape') {
+      setAddStatus(false);
+    }
+  };
+
+  const handleChangeTitle = (e: any) => {
+    setListTitle(e.target.value);
+  };
+
+  const saveList = () => {
+    let listId = shortid.generate();
+    let tempBoard = boards.map((board, index) =>
+      board.boardId === boardId
+        ? {
+            ...board,
+            lists: [...board.lists, { listTitle: listTitle, listId: `l-${listId}`, cards: [], position: 999 }],
+            //position이 꼭 필요할까...? 한번 검토해보자
+          }
+        : board,
+    );
+    console.log(tempBoard);
+    setBoards((prev) => tempBoard);
+  };
+  return (
+    <S.AddListWrapper>
+      {addStatus ? (
+        <S.AddListInput
+          onChange={handleChangeTitle}
+          onKeyDown={handleStatusFalse}
+          onBlur={() => {
+            setAddStatus(false);
+          }}
+          autoFocus
+        ></S.AddListInput>
+      ) : (
+        <S.AddListBtn onClick={handleStatusTrue}>새로운 리스트 추가</S.AddListBtn>
+      )}
+    </S.AddListWrapper>
+  );
+}
+
+export default AddList;

--- a/src/components/Board/AddListStyle.tsx
+++ b/src/components/Board/AddListStyle.tsx
@@ -1,0 +1,27 @@
+import styled from 'styled-components';
+
+export const AddListWrapper = styled.div`
+  width: 272px;
+  flex: 0 0 272px;
+  /* instead of margin right for overflow-x scroll */
+  border-right: 8px solid transparent;
+  margin-left: 4px;
+`;
+
+export const AddListBtn = styled.button`
+  font-size: 1rem;
+  background-color: #ffbdbd;
+`;
+
+export const AddListInput = styled.input`
+  font-size: 1rem;
+  background-color: #ffffffd1;
+  border-radius: 3px;
+  margin: -4px 0;
+  padding: 4px 8px;
+  border: none;
+  &:focus {
+    box-shadow: inset 0 0 0 2px #0079bf;
+    outline: 0;
+  }
+`;

--- a/src/components/Board/AddListStyle.tsx
+++ b/src/components/Board/AddListStyle.tsx
@@ -10,7 +10,14 @@ export const AddListWrapper = styled.div`
 
 export const AddListBtn = styled.button`
   font-size: 1rem;
-  background-color: #ffbdbd;
+  background-color: #d4d4d4;
+  border: none;
+  border-radius: 5px;
+  padding: 7px;
+  &:hover {
+    background-color: #ffffffd1;
+  }
+  transition: all 100ms ease-in;
 `;
 
 export const AddListInput = styled.input`
@@ -21,7 +28,7 @@ export const AddListInput = styled.input`
   padding: 4px 8px;
   border: none;
   &:focus {
-    box-shadow: inset 0 0 0 2px #0079bf;
+    box-shadow: inset 0 0 0 2px #ee8d0d;
     outline: 0;
   }
 `;

--- a/src/components/Board/Board.tsx
+++ b/src/components/Board/Board.tsx
@@ -54,7 +54,7 @@ function Board({ boards, setBoards, boardId }: any) {
         {(provided) => (
           <S.BoardContainer ref={provided.innerRef} {...provided.droppableProps}>
             {lists.map((list: any, index: any) => (
-              <List key={list.listId} listId={list.listId} listData={list} index={index}></List>
+              <List key={list.listId} boardId={boardId} listId={list.listId} listData={list} index={index}></List>
             ))}
             {provided.placeholder}
             <AddList></AddList>

--- a/src/components/Board/Board.tsx
+++ b/src/components/Board/Board.tsx
@@ -1,18 +1,15 @@
 import List from '@/components/Board/List';
 import * as S from '@/components/Board/BoardStyle';
 import { DragDropContext, Droppable, Draggable } from 'react-beautiful-dnd';
+import AddList from './AddList';
 
 function Board({ boards, setBoards, boardId }: any) {
   let [board] = boards.filter((board: any) => board.boardId === boardId);
   let lists = board.lists;
 
-  const onBeforeDragStart = () => {
-    console.log('onBeforeDragStart');
-  };
+  const onBeforeDragStart = () => {};
 
-  const onDragStart = () => {
-    console.log('onDragStart');
-  };
+  const onDragStart = () => {};
 
   const onDragEnd = (result: any) => {
     if (!result.destination) return;
@@ -60,6 +57,7 @@ function Board({ boards, setBoards, boardId }: any) {
               <List key={list.listId} listId={list.listId} listData={list} index={index}></List>
             ))}
             {provided.placeholder}
+            <AddList></AddList>
           </S.BoardContainer>
         )}
       </Droppable>

--- a/src/components/Board/List.tsx
+++ b/src/components/Board/List.tsx
@@ -3,7 +3,7 @@ import * as S from '@/components/Board/ListStyle';
 import Card from '@/components/Board/Card';
 import ListTitle from './ListTitle';
 
-function List({ listId, listData, index }: any) {
+function List({ listId, listData, index, boardId }: any) {
   let cards = listData.cards;
   return (
     <Draggable draggableId={listId} index={index}>
@@ -13,6 +13,7 @@ function List({ listId, listData, index }: any) {
           <S.ListContent>
             <ListTitle
               dragHandleProps={provided.dragHandleProps}
+              boardId={boardId}
               listId={listId}
               title={listData.listTitle}
             ></ListTitle>

--- a/src/components/Board/ListTitle.tsx
+++ b/src/components/Board/ListTitle.tsx
@@ -1,15 +1,64 @@
+import { boardsAtom } from '@/recoil/boardsAtom';
 import React, { useState } from 'react';
+import { useRecoilState } from 'recoil';
 import * as S from './ListTitleStyle';
 
-const ListTitle = ({ setDragBlocking, dragHandleProps, listId, title }: any) => {
-  const titleClick = () => {
-    console.log('타이틀클릭!');
+const ListTitle = ({ dragHandleProps, listId, title, boardId }: any) => {
+  const [boards, setBoards] = useRecoilState(boardsAtom);
+  const [newTitle, setnewTitle] = useState(title);
+  const [editMode, seteditMode] = useState(false);
+
+  const handleTitle = (e: any) => {
+    switch (e.type) {
+      case 'blur':
+        saveTitle();
+
+        seteditMode(false);
+        break;
+      case 'keydown':
+        if (e.code === 'Enter' || e.code === 'Escape') {
+          saveTitle();
+          break;
+        }
+    }
+  };
+
+  const saveTitle = () => {
+    let newBoards = boards.map((board) =>
+      board.boardId === boardId
+        ? {
+            ...board,
+            lists: board.lists.map((list) => (list.listId === listId ? { ...list, listTitle: newTitle } : list)),
+          }
+        : board,
+    );
+    setBoards((prev) => newBoards);
+    seteditMode(false);
   };
 
   return (
     <S.Container {...dragHandleProps}>
-      <S.TextAreaWrapper onClick={titleClick}>
-        <div>{title}</div>
+      <S.TextAreaWrapper>
+        {editMode ? (
+          <S.Textarea
+            onChange={(e) => {
+              setnewTitle((prev: any) => e.target.value);
+            }}
+            value={newTitle}
+            onBlur={handleTitle}
+            onKeyDown={handleTitle}
+            autoFocus
+            spellCheck="false"
+          ></S.Textarea>
+        ) : (
+          <S.Textdiv
+            onClick={() => {
+              seteditMode(true);
+            }}
+          >
+            {newTitle}
+          </S.Textdiv>
+        )}
       </S.TextAreaWrapper>
     </S.Container>
   );

--- a/src/components/Board/ListTitleStyle.tsx
+++ b/src/components/Board/ListTitleStyle.tsx
@@ -8,10 +8,25 @@ export const Container = styled.div`
 `;
 
 export const TextAreaWrapper = styled.div`
+  background-color: #d4d4d4;
   padding: 10px 8px;
   padding-right: 36px;
+  border-radius: 5px;
+`;
 
-  & textarea {
-    font-weight: 600;
-  }
+export const Textdiv = styled.div`
+  width: 256px;
+  height: 25px;
+  font-size: 1rem;
+`;
+
+export const Textarea = styled.textarea`
+  width: 256px;
+  height: 21px;
+  font-size: 1rem;
+  resize: none;
+  background-color: #ffffff;
+  border: none;
+  box-shadow: inset 0 0 0 2px #ee8d0d;
+  outline: 0;
 `;

--- a/src/components/RemoveCard/RemoveCard.tsx
+++ b/src/components/RemoveCard/RemoveCard.tsx
@@ -1,0 +1,19 @@
+import * as S from '@/components/RemoveCard/RemoveCardStyle';
+import Button from '@/components/Button/Button';
+
+function RemoveCard() {
+  const handlePage = () => {
+    location.href = '/workspace';
+  };
+
+  return (
+    <S.CardWrapper>
+      <S.CardTitle>보드를 삭제하였습니다.</S.CardTitle>
+      <Button themes="sign" onClick={handlePage}>
+        Move to Main
+      </Button>
+    </S.CardWrapper>
+  );
+}
+
+export default RemoveCard;

--- a/src/components/RemoveCard/RemoveCardStyle.tsx
+++ b/src/components/RemoveCard/RemoveCardStyle.tsx
@@ -1,0 +1,15 @@
+import styled from 'styled-components';
+
+export const CardWrapper = styled.div`
+  padding: 30px;
+  text-align: center;
+  background-color: #e9e9e9;
+  width: 600px;
+  height: 236px;
+  border-radius: 30px;
+`;
+
+export const CardTitle = styled.div`
+  font-size: 1.5rem;
+  margin: 30px;
+`;

--- a/src/pages/Board/index.tsx
+++ b/src/pages/Board/index.tsx
@@ -4,6 +4,7 @@ import * as S from '@/pages/Board/indexStyle';
 import { useParams } from 'react-router-dom';
 import { useRecoilState } from 'recoil';
 import { boardsAtom } from '@/recoil/boardsAtom';
+import Swal from 'sweetalert2';
 
 function BoardPage() {
   let { boardId } = useParams(); // 추후에 board를 구분하는 변수로 사용!
@@ -33,6 +34,23 @@ function BoardPage() {
     setBoards((prev) => newBoards);
   };
 
+  const handleDeleteBoard = () => {
+    Swal.fire({
+      title: 'Are you sure?',
+      text: "You won't be able to revert this!",
+      icon: 'warning',
+      showCancelButton: true,
+      confirmButtonColor: '#3085d6',
+      cancelButtonColor: '#d33',
+      confirmButtonText: 'Yes, delete it!',
+    }).then(async (result) => {
+      if (result.isConfirmed) {
+        await setBoards((prev) => boards.filter((board) => board.boardId !== boardId));
+        // document.location.href = '/workspace';
+      }
+    });
+  };
+
   return (
     <S.BoardWrapper>
       <S.BoardTitle
@@ -45,6 +63,7 @@ function BoardPage() {
           handleSaveData();
         }}
       ></S.BoardTitle>
+      <S.DeleteBtn onClick={handleDeleteBoard}>보드 삭제</S.DeleteBtn>
       <Board boards={boards} setBoards={setBoards} boardId={boardId} />
     </S.BoardWrapper>
   );

--- a/src/pages/Board/index.tsx
+++ b/src/pages/Board/index.tsx
@@ -13,7 +13,7 @@ function BoardPage() {
   const [boardTitle, setBoardTitle] = useState(board.boardTitle);
 
   const handleChange = (e: any) => {
-    setBoardTitle((prev) => e.target.value);
+    setBoardTitle((prev: any) => e.target.value);
   };
 
   const handleKeyDown = (e: any) => {
@@ -21,8 +21,10 @@ function BoardPage() {
       removeFocus();
       e.preventDefault();
       handleSaveData();
-      let newBoards = boards.map((board) => (board.boardId === boardId ? { ...board, boardTitle: boardTitle } : board));
-      setBoards((prev) => newBoards);
+      let newBoards = boards.map((board: any) =>
+        board.boardId === boardId ? { ...board, boardTitle: boardTitle } : board,
+      );
+      setBoards((prev: any) => newBoards);
     }
   };
 
@@ -30,8 +32,10 @@ function BoardPage() {
     (document.activeElement as HTMLElement).blur();
   };
   const handleSaveData = () => {
-    let newBoards = boards.map((board) => (board.boardId === boardId ? { ...board, boardTitle: boardTitle } : board));
-    setBoards((prev) => newBoards);
+    let newBoards = boards.map((board: any) =>
+      board.boardId === boardId ? { ...board, boardTitle: boardTitle } : board,
+    );
+    setBoards((prev: any) => newBoards);
   };
 
   const handleDeleteBoard = () => {
@@ -43,10 +47,9 @@ function BoardPage() {
       confirmButtonColor: '#3085d6',
       cancelButtonColor: '#d33',
       confirmButtonText: 'Yes, delete it!',
-    }).then(async (result) => {
+    }).then((result) => {
       if (result.isConfirmed) {
-        await setBoards((prev) => boards.filter((board) => board.boardId !== boardId));
-        // document.location.href = '/workspace';
+        location.replace(`/remove/${boardId}`);
       }
     });
   };

--- a/src/pages/Board/indexStyle.tsx
+++ b/src/pages/Board/indexStyle.tsx
@@ -24,3 +24,12 @@ export const BoardTitle = styled.textarea<{ boardTitle: any }>`
     outline: 0;
   }
 `;
+
+export const DeleteBtn = styled.button`
+  border: 0;
+  padding: 10px;
+  border-radius: 10px;
+  &:hover {
+    background-color: #ffcdcd;
+  }
+`;

--- a/src/pages/Remove/index.tsx
+++ b/src/pages/Remove/index.tsx
@@ -1,0 +1,22 @@
+import { useEffect } from 'react';
+import { useParams } from 'react-router-dom';
+import { useRecoilState } from 'recoil';
+import { boardsAtom } from '@/recoil/boardsAtom';
+import RemoveCard from '@/components/RemoveCard/RemoveCard';
+import * as S from '@/pages/Remove/indexStyle';
+
+function Remove() {
+  const { boardId } = useParams();
+  const [boards, setBoards] = useRecoilState(boardsAtom);
+  useEffect(() => {
+    setBoards((prev: any) => boards.filter((board: any) => board.boardId !== boardId));
+  }, []);
+
+  return (
+    <S.Container>
+      <RemoveCard></RemoveCard>
+    </S.Container>
+  );
+}
+
+export default Remove;

--- a/src/pages/Remove/indexStyle.tsx
+++ b/src/pages/Remove/indexStyle.tsx
@@ -1,0 +1,9 @@
+import styled from 'styled-components';
+
+export const Container = styled.div`
+  width: 100vw;
+  height: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+`;

--- a/src/recoil/boardsAtom.tsx
+++ b/src/recoil/boardsAtom.tsx
@@ -1,7 +1,11 @@
 import { atom } from 'recoil';
+import { recoilPersist } from 'recoil-persist';
+
+const { persistAtom } = recoilPersist();
 
 export const boardsAtom = atom({
   key: 'boardsAtom',
+  effects_UNSTABLE: [persistAtom],
   default: [
     {
       boardTitle: '개인 일정 정리 보드',


### PR DESCRIPTION
### 1. 리스트(추가, 타이틀 수정)

리스트를 추가 할 수 있습니다. (디자인 X)

![Animation12](https://user-images.githubusercontent.com/45286570/213134036-a11318c7-b5c6-47f1-9887-aacf0b1e285c.gif)


리스트 타이틀을 수정 할 수 있습니다.

![Animation1](https://user-images.githubusercontent.com/45286570/213133650-929fa623-56ab-45d9-ba07-713afb6932fc.gif)


### 2. 보드 삭제

보드를 삭제 할 수 있습니다.

![Animation12ae](https://user-images.githubusercontent.com/45286570/213134509-597e4ed0-cba3-496c-be24-c07f85a83b10.gif)

### 3. Recoil-persist 적용

보드 데이터에 Recoil-persist를 적용해 보드 데이터들이 localStorage에 저장되어 새로고침을 하더라도 정보가 유지됩니다. Recoil-persist를 써서 데이터를 관리하는 방법말고 좋은 방법 있으면 의견주세용
