### PR TITLE
[MERGE] 워크스페이스 로딩 Skeleton 구현

### DIFF
--- a/src/pages/Boards/index.tsx
+++ b/src/pages/Boards/index.tsx
@@ -3,6 +3,8 @@ import * as S from '@/pages/Boards/indexStyle';
 import { useRecoilState } from 'recoil';
 import { boardsAtom } from '@/recoil/boardsAtom';
 import { defaultData } from '@/components/Board/BoardData';
+import { useState } from 'react';
+import Skeleton from '@mui/material/Skeleton';
 
 const handleAddBoard = (boards: any, setBoards: any) => {
   let newData = defaultData();
@@ -11,8 +13,31 @@ const handleAddBoard = (boards: any, setBoards: any) => {
 };
 
 function Boards({ sidebarOpen }: any) {
+  const [loading, setLoading] = useState(true);
   const [boards, setBoards] = useRecoilState(boardsAtom);
   let personalBoards = boards.filter((board) => board.owner === localStorage.getItem('id'));
+
+  setTimeout(() => {
+    setLoading((prev) => false);
+  }, 1000);
+
+  if (loading)
+    return (
+      <S.PageWrapper isopen={sidebarOpen}>
+        <WorkspaceHeader />
+        <S.BoardContainer>
+          <S.SkeletonWrapper>
+            <Skeleton variant="rounded" animation="wave" width={255} height={170} />
+          </S.SkeletonWrapper>
+          <S.SkeletonWrapper>
+            <Skeleton variant="rounded" animation="wave" width={255} height={170} />
+          </S.SkeletonWrapper>
+          <S.SkeletonWrapper>
+            <Skeleton variant="rounded" animation="wave" width={255} height={170} />
+          </S.SkeletonWrapper>
+        </S.BoardContainer>
+      </S.PageWrapper>
+    );
 
   return (
     <S.PageWrapper isopen={sidebarOpen}>

--- a/src/pages/Boards/indexStyle.tsx
+++ b/src/pages/Boards/indexStyle.tsx
@@ -3,6 +3,7 @@ import { Link } from 'react-router-dom';
 import boardbackground from '@/assets/images/backgroundimg.jpg';
 import { ReactComponent as Add } from '@/assets/images/add.svg';
 import { ReactComponent as UpArrow } from '@/assets/images/upArrow.svg';
+import Skeleton from '@mui/material/Skeleton';
 
 export const WorkspaceWrapper = styled.div`
   display: flex;
@@ -193,4 +194,16 @@ export const ScrollToTopSvg = styled((props) => <UpArrow {...props} />)`
     width: 40px;
     height: 40px;
   }
+`;
+
+export const SkeletonWrapper = styled.div`
+  width: 255px;
+  height: 170px;
+  margin: 25px;
+  position: relative;
+  border-radius: 10px;
+  text-align: center;
+  padding: 10px;
+  font-size: 0.7rem;
+  overflow: hidden;
 `;


### PR DESCRIPTION
### 1. 워크스페이스 로딩 Skeleton 구현
워크스페이스 보드 데이터는 Mock을 통해서 받아오는 데이터가 아니라 recoil에 있는 데이터를 직접 받아오고 있습니다. 그래서 setTimeout을 통해서 1초 딜레이를 줬습니다.
Skeleton은 Mui를 이용해서 구현했습니다^^ 
![aeff](https://user-images.githubusercontent.com/45286570/215516592-1eff4354-7d79-4852-8d16-7d82580fb3bb.gif)
