### PR TITLE
[MERGE] 보드 배경색 변경 구현 & 리스트, 카드 디자인 수정

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2810,7 +2810,6 @@
       "version": "0.2.4",
       "resolved": "https://registry.npmjs.org/@icons/material/-/material-0.2.4.tgz",
       "integrity": "sha512-QPcGmICAPbGLGb6F/yNf/KzKqvFx8z5qx3D1yFqVAjoFmXK35EgyW+cJ57Te3CNsmzblwtzakLGFqHPqrfb4Tw==",
-      "dev": true,
       "peerDependencies": {
         "react": "*"
       }
@@ -22036,8 +22035,7 @@
     "node_modules/lodash-es": {
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.21.tgz",
-      "integrity": "sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw==",
-      "dev": true
+      "integrity": "sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw=="
     },
     "node_modules/lodash.debounce": {
       "version": "4.0.8",
@@ -22304,8 +22302,7 @@
     "node_modules/material-colors": {
       "version": "1.2.6",
       "resolved": "https://registry.npmjs.org/material-colors/-/material-colors-1.2.6.tgz",
-      "integrity": "sha512-6qE4B9deFBIa9YSpOc9O0Sgc43zTeVYbgDT5veRKSlB2+ZuHNoVVxA1L/ckMUayV9Ay9y7Z/SZCLcGteW9i7bg==",
-      "dev": true
+      "integrity": "sha512-6qE4B9deFBIa9YSpOc9O0Sgc43zTeVYbgDT5veRKSlB2+ZuHNoVVxA1L/ckMUayV9Ay9y7Z/SZCLcGteW9i7bg=="
     },
     "node_modules/md5.js": {
       "version": "1.3.5",
@@ -25120,7 +25117,6 @@
       "version": "2.19.3",
       "resolved": "https://registry.npmjs.org/react-color/-/react-color-2.19.3.tgz",
       "integrity": "sha512-LEeGE/ZzNLIsFWa1TMe8y5VYqr7bibneWmvJwm1pCn/eNmrabWDh659JSPn9BuaMpEfU83WTOJfnCcjDZwNQTA==",
-      "dev": true,
       "dependencies": {
         "@icons/material": "^0.2.4",
         "lodash": "^4.17.15",
@@ -25409,7 +25405,6 @@
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/reactcss/-/reactcss-1.2.3.tgz",
       "integrity": "sha512-KiwVUcFu1RErkI97ywr8nvx8dNOpT03rbnma0SSalTYjkrPYaEajR4a/MRt6DZ46K6arDRbWMNHF+xH7G7n/8A==",
-      "dev": true,
       "dependencies": {
         "lodash": "^4.0.1"
       }
@@ -28469,8 +28464,7 @@
     "node_modules/tinycolor2": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/tinycolor2/-/tinycolor2-1.6.0.tgz",
-      "integrity": "sha512-XPaBkWQJdsf3pLKJV9p4qN/S+fm2Oj8AIPo1BTUhg5oxkvm9+SVEGFdhyOz7tTdUTfvxMiAs4sp6/eZO2Ew+pw==",
-      "dev": true
+      "integrity": "sha512-XPaBkWQJdsf3pLKJV9p4qN/S+fm2Oj8AIPo1BTUhg5oxkvm9+SVEGFdhyOz7tTdUTfvxMiAs4sp6/eZO2Ew+pw=="
     },
     "node_modules/tmp": {
       "version": "0.0.33",
@@ -32765,8 +32759,7 @@
     "@icons/material": {
       "version": "0.2.4",
       "resolved": "https://registry.npmjs.org/@icons/material/-/material-0.2.4.tgz",
-      "integrity": "sha512-QPcGmICAPbGLGb6F/yNf/KzKqvFx8z5qx3D1yFqVAjoFmXK35EgyW+cJ57Te3CNsmzblwtzakLGFqHPqrfb4Tw==",
-      "dev": true
+      "integrity": "sha512-QPcGmICAPbGLGb6F/yNf/KzKqvFx8z5qx3D1yFqVAjoFmXK35EgyW+cJ57Te3CNsmzblwtzakLGFqHPqrfb4Tw=="
     },
     "@istanbuljs/load-nyc-config": {
       "version": "1.1.0",
@@ -47305,8 +47298,7 @@
     "lodash-es": {
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.21.tgz",
-      "integrity": "sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw==",
-      "dev": true
+      "integrity": "sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw=="
     },
     "lodash.debounce": {
       "version": "4.0.8",
@@ -47521,8 +47513,7 @@
     "material-colors": {
       "version": "1.2.6",
       "resolved": "https://registry.npmjs.org/material-colors/-/material-colors-1.2.6.tgz",
-      "integrity": "sha512-6qE4B9deFBIa9YSpOc9O0Sgc43zTeVYbgDT5veRKSlB2+ZuHNoVVxA1L/ckMUayV9Ay9y7Z/SZCLcGteW9i7bg==",
-      "dev": true
+      "integrity": "sha512-6qE4B9deFBIa9YSpOc9O0Sgc43zTeVYbgDT5veRKSlB2+ZuHNoVVxA1L/ckMUayV9Ay9y7Z/SZCLcGteW9i7bg=="
     },
     "md5.js": {
       "version": "1.3.5",
@@ -49730,7 +49721,6 @@
       "version": "2.19.3",
       "resolved": "https://registry.npmjs.org/react-color/-/react-color-2.19.3.tgz",
       "integrity": "sha512-LEeGE/ZzNLIsFWa1TMe8y5VYqr7bibneWmvJwm1pCn/eNmrabWDh659JSPn9BuaMpEfU83WTOJfnCcjDZwNQTA==",
-      "dev": true,
       "requires": {
         "@icons/material": "^0.2.4",
         "lodash": "^4.17.15",
@@ -49941,7 +49931,6 @@
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/reactcss/-/reactcss-1.2.3.tgz",
       "integrity": "sha512-KiwVUcFu1RErkI97ywr8nvx8dNOpT03rbnma0SSalTYjkrPYaEajR4a/MRt6DZ46K6arDRbWMNHF+xH7G7n/8A==",
-      "dev": true,
       "requires": {
         "lodash": "^4.0.1"
       }
@@ -52381,8 +52370,7 @@
     "tinycolor2": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/tinycolor2/-/tinycolor2-1.6.0.tgz",
-      "integrity": "sha512-XPaBkWQJdsf3pLKJV9p4qN/S+fm2Oj8AIPo1BTUhg5oxkvm9+SVEGFdhyOz7tTdUTfvxMiAs4sp6/eZO2Ew+pw==",
-      "dev": true
+      "integrity": "sha512-XPaBkWQJdsf3pLKJV9p4qN/S+fm2Oj8AIPo1BTUhg5oxkvm9+SVEGFdhyOz7tTdUTfvxMiAs4sp6/eZO2Ew+pw=="
     },
     "tmp": {
       "version": "0.0.33",

--- a/src/components/Board/AddCardStyle.tsx
+++ b/src/components/Board/AddCardStyle.tsx
@@ -8,13 +8,12 @@ export const AddCardWrapper = styled.div`
 export const AddCardBtn = styled.button`
   width: 100%;
   font-size: 1rem;
-  background-color: #eef4fe;
-  /* box-shadow: #091e4240 0px 1px 1px, #091e4221 0px 0px 1px 1px; */
+  background-color: #ffffff60;
   border: none;
   border-radius: 5px;
   padding: 3px;
   &:hover {
-    box-shadow: #091e4240 0px 4px 8px -2px, #091e4214 0px 0px 0px 1px;
+    box-shadow: #00000040 0px 4px 8px -2px, #00000013 0px 0px 0px 1px;
   }
   transition: all 100ms ease-in;
 `;
@@ -28,7 +27,7 @@ export const AddCardInput = styled.input`
   border-radius: 3px;
   border: none;
   &:focus {
-    box-shadow: inset 0 0 0 2px #bed0f4;
+    box-shadow: inset 0 0 0 2px #00000045;
     outline: 0;
   }
 `;

--- a/src/components/Board/AddListStyle.tsx
+++ b/src/components/Board/AddListStyle.tsx
@@ -11,13 +11,13 @@ export const AddListBtn = styled.button`
   width: 100%;
   height: 45px;
   font-size: 1rem;
-  background-color: #eef4fe;
+  background-color: #ffffff52;
   border: none;
   border-radius: 5px;
   padding: 7px;
   box-shadow: rgba(0, 0, 0, 0.16) 0px 1px 4px;
   &:hover {
-    background-color: #e4ecfa;
+    background-color: #ffffffde;
   }
   transition: all 100ms ease-in;
 `;
@@ -31,7 +31,8 @@ export const AddListInput = styled.input`
   padding: 4px 8px;
   border: none;
   &:focus {
-    box-shadow: inset 0 0 0 2px #e4ecfa;
+    box-shadow: inset 0 0 0 2px #0000005b;
+
     outline: 0;
   }
 `;

--- a/src/components/Board/BoardData.tsx
+++ b/src/components/Board/BoardData.tsx
@@ -8,6 +8,7 @@ export const defaultData = () => {
     boardTitle: '새로운 보드',
     boardId: `b-${boardUId}`,
     owner: localStorage.getItem('id'),
+    backgroundColor: '#ffffff',
     logs: [],
     lists: [],
   };

--- a/src/components/Board/ListStyle.tsx
+++ b/src/components/Board/ListStyle.tsx
@@ -11,7 +11,7 @@ export const ListWrapper = styled.div`
 `;
 
 export const ListContent = styled.div`
-  background-color: white;
+  background-color: #ffffff70;
   border-radius: 10px;
   box-shadow: rgba(0, 0, 0, 0.16) 0px 1px 4px;
 `;

--- a/src/components/Board/ListTitleStyle.tsx
+++ b/src/components/Board/ListTitleStyle.tsx
@@ -12,7 +12,7 @@ export const TextAreaWrapper = styled.div`
   align-items: center;
   justify-content: space-between;
   width: 272px;
-  background-color: #eef4fe;
+  background-color: #ffffffd9;
   min-height: 25px;
   height: auto;
   padding: 10px 15px;
@@ -39,7 +39,7 @@ export const Textarea = styled.textarea`
   font-size: 1.1rem;
   font-weight: 600;
   color: #5d5d5d;
-  background-color: #eef4fe;
+  background-color: #ffffff;
   border: none;
   outline: 0;
   &:focus {

--- a/src/pages/Board/indexStyle.tsx
+++ b/src/pages/Board/indexStyle.tsx
@@ -1,10 +1,10 @@
 import styled from 'styled-components';
 
-export const BoardWrapper = styled.div<{ color: string }>`
+export const BoardWrapper = styled.div<{ backgroundColor: string }>`
   width: 100%;
   height: 100vh;
   padding: 10px 25px;
-  background-color: ${(props) => `${props.color}`}; ;
+  background-color: ${(props) => `${props.backgroundColor}`};
 `;
 
 export const BoardTitle = styled.textarea<{ boardTitle: string }>`
@@ -49,11 +49,10 @@ export const SettingBtn = styled.button`
     background-color: #eef4fe;
   }
 
-  transition: all ease-in 100ms;
+  transition: all ease-in 300ms;
 `;
 
 export const UtilContainer = styled.div`
-  background-color: yellow;
   position: absolute;
   right: 0;
   top: 50;
@@ -89,14 +88,10 @@ export const GoBackBtn = styled.button<{ isGoBackAvavailable: boolean }>`
 export const PopOver = styled.div`
   position: absolute;
   z-index: 2;
-  top: 50px;
-  right: 0px;
+  top: 130px;
+  right: 10px;
 `;
 
 export const Cover = styled.div`
-  position: fixed;
-  top: 0px;
-  right: 0px;
-  bottom: 0px;
-  left: 0px;
+  background-color: red;
 `;

--- a/src/recoil/boardsDummy.tsx
+++ b/src/recoil/boardsDummy.tsx
@@ -3,6 +3,7 @@ export const boardsDummy = [
     boardTitle: '개인 일정 정리 보드',
     boardId: '1',
     owner: 'bwj0509',
+    backgroundColor: '#a41010',
     logs: [],
     lists: [
       {

--- a/src/type.tsx
+++ b/src/type.tsx
@@ -2,6 +2,7 @@ export interface BoardInterface {
   boardTitle: string;
   boardId: string;
   owner: string;
+  backgroundColor: string;
   logs: LogsInterface[];
   lists: ListInterface[];
 }


### PR DESCRIPTION
### 1. 보드 배경색 변경하면 데이터 저장 될 수 있도록 구현했습니다.

설정 버튼을 클릭해 칼라피커를 오픈 할 수 있고 원하는 색을 선택한 뒤에 설정 버튼을 한번 더 누르면 배경색이 적용됩니다.

![efe](https://user-images.githubusercontent.com/45286570/216938905-cc1ddcfe-4828-44f0-89e7-8994a0d493a1.gif)


### 2. 리스트 ,카드 디자인 수정

리스트 배경색에는 불투명한 색을 주어 배경 색과 어울리게 하였습니다. 