### PR TITLE
[MERGE] 캘린더 로직 구현, 보드 배경에 따른 보드 타이틀 색 변경

### DIFF
--- a/src/components/Board/Board.tsx
+++ b/src/components/Board/Board.tsx
@@ -98,8 +98,8 @@ function Board({ boards, setBoards, boardId }: BoardProps) {
           )}
         </Droppable>
       </DragDropContext>
-      {lists.length === 0 && <Welcome ment={0} />}
-      {lists.length === 1 && lists[0].cards.length === 0 && <Welcome ment={1} />}
+      {lists.length === 0 && <Welcome brightness={board.brightness} mentIndex={0} />}
+      {lists.length === 1 && lists[0].cards.length === 0 && <Welcome brightness={board.brightness} mentIndex={1} />}
       {selectedCardId.isModalopen && <CardModal></CardModal>}
     </>
   );

--- a/src/components/Board/Board.tsx
+++ b/src/components/Board/Board.tsx
@@ -98,8 +98,10 @@ function Board({ boards, setBoards, boardId }: BoardProps) {
           )}
         </Droppable>
       </DragDropContext>
-      {lists.length === 0 && <Welcome brightness={board.brightness} mentIndex={0} />}
-      {lists.length === 1 && lists[0].cards.length === 0 && <Welcome brightness={board.brightness} mentIndex={1} />}
+      {lists.length === 0 && <Welcome brightness={board.brightness} welcomeMessageIndex={0} />}
+      {lists.length === 1 && lists[0].cards.length === 0 && (
+        <Welcome brightness={board.brightness} welcomeMessageIndex={1} />
+      )}
       {selectedCardId.isModalopen && <CardModal></CardModal>}
     </>
   );

--- a/src/components/Board/BoardData.tsx
+++ b/src/components/Board/BoardData.tsx
@@ -9,6 +9,7 @@ export const defaultData = () => {
     boardId: `b-${boardUId}`,
     owner: localStorage.getItem('id'),
     backgroundColor: '#ffffff',
+    brightness: 255,
     logs: [],
     lists: [],
   };

--- a/src/components/Board/Welcome.tsx
+++ b/src/components/Board/Welcome.tsx
@@ -2,18 +2,19 @@ import * as S from '@/components/Board/WelcomeStyle';
 import { TypeAnimation } from 'react-type-animation';
 
 interface WelcomeProps {
-  ment: number;
+  mentIndex: number;
+  brightness: number;
 }
 
-function Welcome({ ment }: WelcomeProps) {
+function Welcome({ mentIndex, brightness }: WelcomeProps) {
   const sequence = [
     [`😀 Welcome ${localStorage.getItem('id')}.`, 2000, '👆 Make your first List.', 2000],
     ['👆 Make your Card!', 2000, '👆 Make everything with Timmyloom.', 2000],
   ];
 
   return (
-    <S.WelcomeWrapper>
-      <TypeAnimation sequence={sequence[ment]} wrapper="div" speed={75} repeat={Infinity} />
+    <S.WelcomeWrapper brightness={brightness}>
+      <TypeAnimation sequence={sequence[mentIndex]} wrapper="div" speed={75} repeat={Infinity} />
     </S.WelcomeWrapper>
   );
 }

--- a/src/components/Board/Welcome.tsx
+++ b/src/components/Board/Welcome.tsx
@@ -2,11 +2,11 @@ import * as S from '@/components/Board/WelcomeStyle';
 import { TypeAnimation } from 'react-type-animation';
 
 interface WelcomeProps {
-  mentIndex: number;
+  welcomeMessageIndex: number;
   brightness: number;
 }
 
-function Welcome({ mentIndex, brightness }: WelcomeProps) {
+function Welcome({ welcomeMessageIndex, brightness }: WelcomeProps) {
   const sequence = [
     [`😀 Welcome ${localStorage.getItem('id')}.`, 2000, '👆 Make your first List.', 2000],
     ['👆 Make your Card!', 2000, '👆 Make everything with Timmyloom.', 2000],
@@ -14,7 +14,7 @@ function Welcome({ mentIndex, brightness }: WelcomeProps) {
 
   return (
     <S.WelcomeWrapper brightness={brightness}>
-      <TypeAnimation sequence={sequence[mentIndex]} wrapper="div" speed={75} repeat={Infinity} />
+      <TypeAnimation sequence={sequence[welcomeMessageIndex]} wrapper="div" speed={75} repeat={Infinity} />
     </S.WelcomeWrapper>
   );
 }

--- a/src/components/Board/WelcomeStyle.tsx
+++ b/src/components/Board/WelcomeStyle.tsx
@@ -1,6 +1,7 @@
 import styled from 'styled-components';
 
-export const WelcomeWrapper = styled.div`
+export const WelcomeWrapper = styled.div<{ brightness: number }>`
   margin: 10px 20px;
   font-size: 2rem;
+  color: ${(props) => (props.brightness > 100 ? '#000000' : '#ffffff')};
 `;

--- a/src/pages/Board/index.tsx
+++ b/src/pages/Board/index.tsx
@@ -24,6 +24,7 @@ function BoardPage() {
   const [isLogOpen, setIsLogOpen] = useState(false);
   const [isColorPickerOpen, setIsColorPickerOpen] = useState(false);
   const [backgroundColor, setBackgroundColor] = useState(board.backgroundColor);
+  const [brightness, setBrightness] = useState(255);
 
   useEffect(() => {
     setTemporaryBoard((prev) => []);
@@ -32,7 +33,9 @@ function BoardPage() {
   useDidMountEffect(() => {
     if (!isColorPickerOpen) {
       setBoards((prev) =>
-        boards.map((board) => (board.boardId === boardId ? { ...board, backgroundColor: backgroundColor } : board)),
+        boards.map((board) =>
+          board.boardId === boardId ? { ...board, backgroundColor: backgroundColor, brightness: brightness } : board,
+        ),
       );
       const Toast = Swal.mixin({
         toast: true,
@@ -104,6 +107,7 @@ function BoardPage() {
   };
 
   const handleColorChange = (sketchColor: { rgb: { r: number; g: number; b: number; a?: number | undefined } }) => {
+    setBrightness((prev) => ((sketchColor.rgb.r + sketchColor.rgb.g + sketchColor.rgb.b) / 3) * sketchColor.rgb.a);
     setBackgroundColor('#' + rgbHex(sketchColor.rgb.r, sketchColor.rgb.g, sketchColor.rgb.b, sketchColor.rgb.a));
   };
 
@@ -112,6 +116,7 @@ function BoardPage() {
       <S.BoardTitle
         spellCheck="false"
         boardTitle={boardTitle}
+        brightness={board.brightness}
         value={boardTitle}
         onChange={handleChange}
         onKeyDown={handleKeyDown}

--- a/src/pages/Board/indexStyle.tsx
+++ b/src/pages/Board/indexStyle.tsx
@@ -7,7 +7,8 @@ export const BoardWrapper = styled.div<{ backgroundColor: string }>`
   background-color: ${(props) => `${props.backgroundColor}`};
 `;
 
-export const BoardTitle = styled.textarea<{ boardTitle: string }>`
+export const BoardTitle = styled.textarea<{ boardTitle: string; brightness: number }>`
+  color: ${(props) => `${props.brightness > 100 ? '#000000' : '#ffffff'}`};
   cursor: pointer;
   width: ${(props) => `${props.boardTitle.length * 23}px`};
   min-width: 200px;
@@ -24,6 +25,7 @@ export const BoardTitle = styled.textarea<{ boardTitle: string }>`
     background: white;
     box-shadow: inset 0 0 0 2px #5d5d5d;
     outline: 0;
+    color: #000000;
   }
 `;
 

--- a/src/pages/Boards/index.tsx
+++ b/src/pages/Boards/index.tsx
@@ -50,7 +50,7 @@ function Boards({ sidebarOpen }: BoardsProps) {
       <S.ContentWrapper isopen={sidebarOpen}>
         <S.BoardContainer>
           {personalBoards.map((board: BoardData, index: number) => (
-            <S.BoardWrapper key={index} to={`/workspace/${board.boardId}`}>
+            <S.BoardWrapper key={index} to={`/workspace/${board.boardId}`} brightness={board.brightness}>
               <S.BoardTitle>{board.boardTitle}</S.BoardTitle>
               <S.BackgroundWrapper backgroundColor={board.backgroundColor} />
             </S.BoardWrapper>

--- a/src/pages/Boards/indexStyle.tsx
+++ b/src/pages/Boards/indexStyle.tsx
@@ -1,9 +1,7 @@
 import styled from 'styled-components';
 import { Link } from 'react-router-dom';
-import boardbackground from '@/assets/images/backgroundimg.jpg';
 import { ReactComponent as Add } from '@/assets/images/add.svg';
 import { ReactComponent as UpArrow } from '@/assets/images/upArrow.svg';
-import Skeleton from '@mui/material/Skeleton';
 
 export const WorkspaceWrapper = styled.div`
   display: flex;
@@ -76,7 +74,7 @@ export const BoardTitle = styled.div`
   }
 `;
 
-export const BoardWrapper = styled(Link)`
+export const BoardWrapper = styled(Link)<{ brightness: number }>`
   width: 255px;
   height: 170px;
   margin: 25px;
@@ -108,6 +106,7 @@ export const BoardWrapper = styled(Link)`
     transform: translate(-45%, -10%);
     width: 300px;
     transition: all 300ms;
+    color: ${(props) => (props.brightness > 100 ? '#000000' : '#ffffff')};
   }
 
   @media screen and (max-width: 425px) {

--- a/src/pages/Calendar/index.tsx
+++ b/src/pages/Calendar/index.tsx
@@ -1,14 +1,21 @@
-import { useState } from 'react';
 import * as S from '@/pages/Calendar/indexStyle';
-import FullCalendar from '@fullcalendar/react'; // must go before plugins
-import dayGridPlugin from '@fullcalendar/daygrid'; // a plugin!
+import FullCalendar from '@fullcalendar/react';
+import dayGridPlugin from '@fullcalendar/daygrid';
 import { useRecoilState } from 'recoil';
 import { boardsAtom } from '@/recoil/boards';
 import { BoardData, ListData, CardData } from '@/type';
 
+interface eventData {
+  title: string;
+  start: string;
+  end: string;
+  color: string;
+  textColor: string;
+}
+
 function Calendar() {
   const [boards, setBoards] = useRecoilState(boardsAtom);
-  let events: any = [];
+  let events: eventData[] = [];
   boards.forEach((board: BoardData) =>
     board.lists.forEach((list: ListData) =>
       list.cards.forEach((card: CardData) => {
@@ -28,11 +35,13 @@ function Calendar() {
           title: card.cardTitle,
           start: startDate,
           end: endDate,
+          color: board.backgroundColor,
+          textColor: board.brightness > 100 ? '#000000' : '#ffffff',
         });
       }),
     ),
   );
-  console.log(events);
+
   return (
     <S.Container>
       <FullCalendar

--- a/src/recoil/boardsDummy.tsx
+++ b/src/recoil/boardsDummy.tsx
@@ -4,6 +4,7 @@ export const boardsDummy = [
     boardId: '1',
     owner: 'bwj0509',
     backgroundColor: '#a41010',
+    brightness: 100,
     logs: [],
     lists: [
       {

--- a/src/type.tsx
+++ b/src/type.tsx
@@ -3,6 +3,7 @@ export interface BoardData {
   boardId: string;
   owner: string;
   backgroundColor: string;
+  brightness: number;
   logs: LogsInterface[];
   lists: ListData[];
 }


### PR DESCRIPTION
### 1. 캘린더 로직 구현

사용자가 만든 카드를 캘린더 페이지에서 한눈에 볼 수 있습니다.  캘린더에 들어가는 색은 보드의 배경색과 동일하고, 글자 색은 보드의 배경색을 분석해서 어두워지면 검은 -> 흰 으로 변하게 하였습니다. 

계산식은 (R+G+B) / A 이며 값은 100을 기준으로 하였습니다.


![image](https://user-images.githubusercontent.com/45286570/217167373-25898218-f068-40f2-b058-bcfb03ccd769.png)



### 2. 보드 배경에 따른 보드 타이틀 색 변경

보드의 색상이 어두워짐에 따라 보드 타이틀이 안보이는 현상이 있었습니다. 
위에 계산식을 똑같이 적용해서 보드색을 변경합니다.

![image](https://user-images.githubusercontent.com/45286570/217167971-841f568e-21ad-48f2-8f77-bb12992498af.png)




