### PR TITLE
[MERGE] Card의 완료/미완료 여부 데이터 저장 및 Opacity 조절 구현

### DIFF
--- a/src/components/Board/AddCard.tsx
+++ b/src/components/Board/AddCard.tsx
@@ -57,6 +57,7 @@ function AddCard({ listId }: AddCardProps) {
                         cardTitle: cardTitle,
                         cardId: `c-${cardId}`,
                         cardDescription: '',
+                        isDone: false,
                         date: {
                           from: {
                             year: new Date().getFullYear(),

--- a/src/components/Board/Card.tsx
+++ b/src/components/Board/Card.tsx
@@ -35,6 +35,7 @@ const Card = ({ listId, cardId, cardData, index, boardId }: CardProps) => {
       cardData: cardData,
     }));
   };
+
   const handleDeleteCard = (e: React.MouseEvent<HTMLElement>) => {
     e.stopPropagation();
     setTemporaryBoard((prev) => [...prev, boards]);
@@ -56,6 +57,28 @@ const Card = ({ listId, cardId, cardData, index, boardId }: CardProps) => {
     setBoards((prev) => newBoards);
   };
 
+  const handleDoneStatus = (e: React.MouseEvent<HTMLInputElement, MouseEvent>) => {
+    e.stopPropagation();
+    const newBoards = boards.map((board) =>
+      board.boardId === boardId
+        ? {
+            ...board,
+            lists: board.lists.map((list) =>
+              list.listId === listId
+                ? {
+                    ...list,
+                    cards: list.cards.map((card) =>
+                      card.cardId === cardId ? { ...card, isDone: !checkbox.state } : card,
+                    ),
+                  }
+                : list,
+            ),
+          }
+        : board,
+    );
+    setBoards((prev) => newBoards);
+  };
+
   return (
     <>
       <Draggable draggableId={cardId} index={index}>
@@ -65,16 +88,14 @@ const Card = ({ listId, cardId, cardData, index, boardId }: CardProps) => {
             {...draggableProvided.draggableProps}
             {...draggableProvided.dragHandleProps}
           >
-            <S.TextAreaWrapper onClick={handleSaveModalData}>
+            <S.TextAreaWrapper onClick={handleSaveModalData} isDone={cardData.isDone}>
               <S.CardHeaderWrapper>
                 <S.CheckboxCustom
                   icon={<ImCheckmark className="svg" data-type="svg" color="white" />}
                   color="info"
                   {...checkbox}
-                  onClick={(e: React.MouseEvent<HTMLInputElement, MouseEvent>) => {
-                    e.stopPropagation();
-                    console.log(checkbox.state);
-                  }}
+                  checked={cardData.isDone}
+                  onClick={handleDoneStatus}
                 />
 
                 <S.CardTitleWrapper>{cardData.cardTitle}</S.CardTitleWrapper>

--- a/src/components/Board/CardStyle.tsx
+++ b/src/components/Board/CardStyle.tsx
@@ -11,7 +11,7 @@ export const CardDraggable = styled.div`
   position: relative;
 `;
 
-export const TextAreaWrapper = styled.div`
+export const TextAreaWrapper = styled.div<{ isDone: boolean }>`
   display: flex;
   justify-content: center;
   flex-direction: column;
@@ -19,6 +19,7 @@ export const TextAreaWrapper = styled.div`
   margin-bottom: 15px;
   height: auto;
   border-radius: 5px;
+  opacity: ${(props) => (props.isDone ? '0.4' : '1')};
 
   box-shadow: #091e4240 0px 1px 1px, #091e4221 0px 0px 1px 1px;
 

--- a/src/recoil/boardsDummy.tsx
+++ b/src/recoil/boardsDummy.tsx
@@ -15,6 +15,7 @@ export const boardsDummy = [
             cardTitle: '헬스 하기',
             cardId: '104',
             cardDescription: 'cardDescription test message',
+            isDone: false,
             date: {
               from: { year: 2023, month: 2, day: 3 },
               to: { year: 2023, month: 2, day: 10 },
@@ -24,6 +25,7 @@ export const boardsDummy = [
             cardTitle: '버스 예매하기',
             cardId: '105',
             cardDescription: 'cardDescription test message',
+            isDone: false,
             date: {
               from: { year: 2023, month: 2, day: 3 },
               to: { year: 2023, month: 2, day: 10 },
@@ -33,6 +35,7 @@ export const boardsDummy = [
             cardTitle: '타입스크립트 공부',
             cardId: '106',
             cardDescription: 'cardDescription test message',
+            isDone: false,
             date: {
               from: { year: 2023, month: 2, day: 3 },
               to: { year: 2023, month: 2, day: 10 },
@@ -42,6 +45,7 @@ export const boardsDummy = [
             cardTitle: '독서 2권하기',
             cardId: '107',
             cardDescription: 'cardDescription test message',
+            isDone: false,
             date: {
               from: { year: 2023, month: 2, day: 3 },
               to: { year: 2023, month: 2, day: 10 },
@@ -57,6 +61,7 @@ export const boardsDummy = [
             cardTitle: 'JEST 공부',
             cardId: '101',
             cardDescription: 'cardDescription test message',
+            isDone: false,
             date: {
               from: { year: 2023, month: 2, day: 3 },
               to: { year: 2023, month: 2, day: 10 },
@@ -66,6 +71,7 @@ export const boardsDummy = [
             cardTitle: 'StoryBook 공부',
             cardId: '102',
             cardDescription: 'cardDescription test message',
+            isDone: false,
             date: {
               from: { year: 2023, month: 2, day: 3 },
               to: { year: 2023, month: 2, day: 10 },
@@ -75,6 +81,7 @@ export const boardsDummy = [
             cardTitle: 'MSW 공부',
             cardId: '103',
             cardDescription: 'cardDescription test message',
+            isDone: false,
             date: {
               from: { year: 2023, month: 2, day: 3 },
               to: { year: 2023, month: 2, day: 10 },
@@ -90,6 +97,7 @@ export const boardsDummy = [
             cardTitle: '취업하기',
             cardId: '108',
             cardDescription: 'cardDescription test message',
+            isDone: false,
             date: {
               from: { year: 2023, month: 2, day: 3 },
               to: { year: 2023, month: 2, day: 10 },
@@ -99,6 +107,7 @@ export const boardsDummy = [
             cardTitle: '축구 예매하기',
             cardId: '109',
             cardDescription: 'cardDescription test message',
+            isDone: false,
             date: {
               from: { year: 2023, month: 2, day: 3 },
               to: { year: 2023, month: 2, day: 10 },
@@ -108,6 +117,7 @@ export const boardsDummy = [
             cardTitle: '타입스크립트 마스터',
             cardId: '110',
             cardDescription: 'cardDescription test message',
+            isDone: false,
             date: {
               from: { year: 2023, month: 2, day: 3 },
               to: { year: 2023, month: 2, day: 10 },
@@ -117,6 +127,7 @@ export const boardsDummy = [
             cardTitle: '독서 200권하기',
             cardId: '111',
             cardDescription: 'cardDescription test message',
+            isDone: false,
             date: {
               from: { year: 2023, month: 2, day: 3 },
               to: { year: 2023, month: 2, day: 10 },

--- a/src/type.tsx
+++ b/src/type.tsx
@@ -18,6 +18,7 @@ export interface CardData {
   cardTitle: string;
   cardId: string;
   cardDescription: string;
+  isDone: boolean;
   date: DateRangeInterface;
 }
 


### PR DESCRIPTION
### 1. Card의 완료/미완료 여부 데이터 저장 및 Opacity 조절 구현

Card 항목에 대해서 완료 체크를 할 경우 Opacity 조절을 구현하였습니다. Recoil에 저장되어 새로고침해도 정보가 유지됩니다.

![grrg](https://user-images.githubusercontent.com/45286570/217730631-efb78d22-0b6a-4e77-9c25-da8f79c6ead1.gif)
